### PR TITLE
Add basic landing page

### DIFF
--- a/tewtopia/src/app/globals.css
+++ b/tewtopia/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tewtopia/src/app/layout.tsx
+++ b/tewtopia/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Tewtopia',
+  description: 'Connecting students and tutors',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/tewtopia/src/app/page.tsx
+++ b/tewtopia/src/app/page.tsx
@@ -1,0 +1,13 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4">
+      <h1 className="text-4xl font-bold mb-4">Welcome to Tewtopia</h1>
+      <p className="mb-4 text-center max-w-md">
+        Tewtopia connects students with the perfect tutors to help them succeed.
+      </p>
+      <button className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded">
+        Get Started
+      </button>
+    </main>
+  );
+}

--- a/tewtopia/tailwind.config.mjs
+++ b/tewtopia/tailwind.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './src/app/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- set up Tailwind CSS
- add global layout and styling
- create a landing page connecting students with tutors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843caf1e7e8832ca734c417895fcb72