### PR TITLE
Add auth and main pages with links

### DIFF
--- a/tewtopia/src/app/auth/page.tsx
+++ b/tewtopia/src/app/auth/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function AuthPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // In a real app, you'd authenticate here
+    router.push('/main');
+  };
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4">
+      <h1 className="text-2xl font-bold mb-4">Log In</h1>
+      <form onSubmit={handleSubmit} className="w-full max-w-xs space-y-4">
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full p-2 border rounded"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full p-2 border rounded"
+          required
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded"
+        >
+          Log In
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/tewtopia/src/app/main/page.tsx
+++ b/tewtopia/src/app/main/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function MainPage() {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="flex min-h-screen">
+      <aside
+        className={`${open ? 'w-48' : 'w-12'} bg-gray-800 text-white transition-all`}
+      >
+        <button
+          onClick={() => setOpen(!open)}
+          className="p-2 focus:outline-none"
+        >
+          {open ? '<<' : '>>'}
+        </button>
+        {open && (
+          <nav className="mt-4 space-y-2">
+            <a href="#" className="block px-4 py-2 hover:bg-gray-700">
+              Dashboard
+            </a>
+            <a href="#" className="block px-4 py-2 hover:bg-gray-700">
+              Profile
+            </a>
+            <a href="#" className="block px-4 py-2 hover:bg-gray-700">
+              Settings
+            </a>
+          </nav>
+        )}
+      </aside>
+      <main className="flex-1 p-4">
+        <h1 className="text-2xl font-bold mb-4">Main Page</h1>
+        <p>Welcome! Use the side menu to navigate.</p>
+      </main>
+    </div>
+  );
+}

--- a/tewtopia/src/app/page.tsx
+++ b/tewtopia/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-4">
@@ -5,9 +7,12 @@ export default function Home() {
       <p className="mb-4 text-center max-w-md">
         Tewtopia connects students with the perfect tutors to help them succeed.
       </p>
-      <button className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded">
+      <Link
+        href="/auth"
+        className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded"
+      >
         Get Started
-      </button>
+      </Link>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- link from landing page to new auth page
- add a simple login form that routes to `/main`
- create main page with collapsible side menu

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843d2b4f7d0832cbc3a24dcbd6b92ae