### PR TITLE
Switch to default layout plugin

### DIFF
--- a/tewtopia/package-lock.json
+++ b/tewtopia/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@react-pdf-viewer/core": "^3.12.0",
+        "@react-pdf-viewer/default-layout": "^3.12.0",
         "@react-pdf-viewer/toolbar": "^3.12.0",
         "next": "15.3.3",
         "react": "^19.0.0",
@@ -1074,6 +1075,32 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@react-pdf-viewer/attachment": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/attachment/-/attachment-3.12.0.tgz",
+      "integrity": "sha512-mhwrYJSIpCvHdERpLUotqhMgSjhtF+BTY1Yb9Fnzpcq3gLZP+Twp5Rynq21tCrVdDizPaVY7SKu400GkgdMfZw==",
+      "license": "https://react-pdf-viewer.dev/license",
+      "dependencies": {
+        "@react-pdf-viewer/core": "3.12.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@react-pdf-viewer/bookmark": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/bookmark/-/bookmark-3.12.0.tgz",
+      "integrity": "sha512-i7nEit8vIFMAES8RFGwprZ9cXOOZb9ZStPW6E6yuObJEXcvBj/ctsbBJGZxqUZOGklM0JoB7sjHyxAriHfe92A==",
+      "license": "https://react-pdf-viewer.dev/license",
+      "dependencies": {
+        "@react-pdf-viewer/core": "3.12.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@react-pdf-viewer/core": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/@react-pdf-viewer/core/-/core-3.12.0.tgz",
@@ -1081,6 +1108,23 @@
       "license": "https://react-pdf-viewer.dev/license",
       "peerDependencies": {
         "pdfjs-dist": "^2.16.105 || ^3.0.279",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@react-pdf-viewer/default-layout": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/default-layout/-/default-layout-3.12.0.tgz",
+      "integrity": "sha512-K2fS4+TJynHxxCBFuIDiFuAw3nqOh4bkBgtVZ/2pGvnFn9lLg46YGLMnTXCQqtyZzzXYh696jmlFViun3is4pA==",
+      "license": "https://react-pdf-viewer.dev/license",
+      "dependencies": {
+        "@react-pdf-viewer/attachment": "3.12.0",
+        "@react-pdf-viewer/bookmark": "3.12.0",
+        "@react-pdf-viewer/core": "3.12.0",
+        "@react-pdf-viewer/thumbnail": "3.12.0",
+        "@react-pdf-viewer/toolbar": "3.12.0"
+      },
+      "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
@@ -1219,6 +1263,19 @@
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/@react-pdf-viewer/theme/-/theme-3.12.0.tgz",
       "integrity": "sha512-cdBi+wR1VOZ6URCcO9plmAZQu4ZGFcd7HJdBe7VIFiGyrvl9I/Of74ONLycnDImSuONt8D3uNjPBLieeaShVeg==",
+      "license": "https://react-pdf-viewer.dev/license",
+      "dependencies": {
+        "@react-pdf-viewer/core": "3.12.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@react-pdf-viewer/thumbnail": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/thumbnail/-/thumbnail-3.12.0.tgz",
+      "integrity": "sha512-Vc8j3bO6wumWZV4o6pAbktPWKDSC9tQAzOCJ3cof541u4i44C11ccYC4W9aNcsMMUSO3bNwAGWtP8OFthV5akQ==",
       "license": "https://react-pdf-viewer.dev/license",
       "dependencies": {
         "@react-pdf-viewer/core": "3.12.0"

--- a/tewtopia/package.json
+++ b/tewtopia/package.json
@@ -10,20 +10,21 @@
   },
   "dependencies": {
     "@react-pdf-viewer/core": "^3.12.0",
+    "@react-pdf-viewer/default-layout": "^3.12.0",
     "@react-pdf-viewer/toolbar": "^3.12.0",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/tewtopia/src/app/main/page.tsx
+++ b/tewtopia/src/app/main/page.tsx
@@ -3,16 +3,14 @@
 import { useEffect, useState } from 'react';
 import rawPdf from '../pdf/testByteArray';
 import { Worker, Viewer } from '@react-pdf-viewer/core';
-import { toolbarPlugin } from '@react-pdf-viewer/toolbar';
+import { defaultLayoutPlugin } from '@react-pdf-viewer/default-layout';
 import '@react-pdf-viewer/core/lib/styles/index.css';
-import '@react-pdf-viewer/toolbar/lib/styles/index.css';
+import '@react-pdf-viewer/default-layout/lib/styles/index.css';
 
 export default function MainPage() {
   const [open, setOpen] = useState(true);
-  const [previewOpen, setPreviewOpen] = useState(false);
   const [pdfUrl, setPdfUrl] = useState<string>();
-  const toolbarPluginInstance = toolbarPlugin();
-  const { Toolbar } = toolbarPluginInstance;
+  const defaultLayoutPluginInstance = defaultLayoutPlugin();
 
   useEffect(() => {
     const byteString = atob(rawPdf.trim());
@@ -41,39 +39,13 @@ export default function MainPage() {
         )}
       </aside>
       <main className="flex flex-1 bg-white p-6">
-        <div className={`relative transition-all ${previewOpen ? 'w-64' : 'w-0'} overflow-hidden border-r`}>
-          {pdfUrl && <iframe src={pdfUrl} className="h-full w-full" />}
-        </div>
-        <div className="flex-1 pl-4">
-          <button
-            onClick={() => setPreviewOpen(!previewOpen)}
-            className="mb-2 rounded border px-2 text-sm"
-          >
-            {previewOpen ? 'Hide Preview' : 'Show Preview'}
-          </button>
+        <div className="flex-1">
           <h1 className="text-2xl font-bold mb-4">Main Page</h1>
           <p className="mb-4">Welcome! Use the side menu to navigate.</p>
           {pdfUrl && (
-            <div className="flex h-[80vh] flex-col border">
+            <div className="h-[80vh] border">
               <Worker workerUrl="https://unpkg.com/pdfjs-dist@3.11.174/build/pdf.worker.min.js">
-                <Toolbar>
-                  {(slots) => {
-                    const { ZoomOut, ZoomIn, CurrentPageInput, NumberOfPages, Download } = slots;
-                    return (
-                      <div className="flex items-center gap-2 border-b p-2">
-                        <ZoomOut />
-                        <ZoomIn />
-                        <div className="flex items-center gap-1">
-                          <CurrentPageInput /> / <NumberOfPages />
-                        </div>
-                        <Download />
-                      </div>
-                    );
-                  }}
-                </Toolbar>
-                <div className="flex-1 overflow-hidden">
-                  <Viewer fileUrl={pdfUrl} plugins={[toolbarPluginInstance]} />
-                </div>
+                <Viewer fileUrl={pdfUrl} plugins={[defaultLayoutPluginInstance]} />
               </Worker>
             </div>
           )}


### PR DESCRIPTION
## Summary
- add default-layout plugin dependency
- swap PDF viewer to use the default layout plugin instead of the toolbar plugin

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found: Can't resolve 'canvas')*

------
https://chatgpt.com/codex/tasks/task_e_6854e617a954832c898aa36db8372981